### PR TITLE
Add hard cap for ship loading cost

### DIFF
--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -59,6 +59,7 @@ using Robust.Server.Player;
 using Robust.Shared.Log;
 using Content.Shared.Shuttles.Components;
 using Content.Shared._HL.Shipyard;
+using Content.Shared.CCVar;
 
 // Suppress naming style rule for the _NF namespace prefix (project convention)
 #pragma warning disable IDE1006
@@ -520,7 +521,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         // Calculate appraisal cost for the loaded ship (charge 10% of appraisal)
         var fullAppraisal = _pricing.AppraiseGrid(shuttleUid, null);
         var appraisalCost = (int) MathF.Round((float) fullAppraisal * 0.1f);
-        appraisalCost = int.Clamp(appraisalCost, 0, 50_000);
+        appraisalCost = int.Clamp(appraisalCost, 0, _configManager.GetCVar(CCVars.ShipyardLoadMaxTransactionPrice));
 
         // Check if player has a bank account and session to charge them
         if (!_player.TryGetSessionByEntity(player, out var playerSession))

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -520,6 +520,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         // Calculate appraisal cost for the loaded ship (charge 10% of appraisal)
         var fullAppraisal = _pricing.AppraiseGrid(shuttleUid, null);
         var appraisalCost = (int) MathF.Round((float) fullAppraisal * 0.1f);
+        appraisalCost = int.Clamp(appraisalCost, 0, 50_000);
 
         // Check if player has a bank account and session to charge them
         if (!_player.TryGetSessionByEntity(player, out var playerSession))

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
@@ -694,6 +694,12 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     {
         try
         {
+            if (!_configManager.GetCVar(CCVars.UniqueServerHashValidationEnabled))
+            {
+                _sawmill.Warning("[SECURITY] Ship hash verification is disabled by CVar; allowing ship load without hash validation.");
+                return true;
+            }
+
             // 1. Extract the hash embedded in the YAML string
             var extractedHash = ExtractHashFromYaml(yamlData);
 

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -201,6 +201,12 @@ public sealed partial class CCVars
     public static readonly CVarDef<string> UniqueServerHash =
         CVarDef.Create("shuttle.unique_server_hash", "U2FuZHdpY2hTZWN0b3I=", CVar.SERVERONLY);
 
+    /// <summary>
+    ///     Maximum charge applied when loading a ship through a shipyard console.
+    /// </summary>
+    public static readonly CVarDef<int> ShipyardLoadMaxTransactionPrice =
+        CVarDef.Create("shuttle.shipyard_load_max_transaction_price", 50000, CVar.SERVERONLY);
+
     #region Orphaned Grid Cleanup
 
     /// <summary>

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -197,9 +197,16 @@ public sealed partial class CCVars
 
     /// <summary>
     ///     To prevent cheating the server will embed this hash into the player's saved shuttle/ship's file.
+    ///     CHANGE THIS OR THIS SYSTEM IS PRACTICALLY USELESS!
     /// </summary>
     public static readonly CVarDef<string> UniqueServerHash =
         CVarDef.Create("shuttle.unique_server_hash", "U2FuZHdpY2hTZWN0b3I=", CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Master toggle for verifying the embedded ship security hash when loading ships.
+    /// </summary>
+    public static readonly CVarDef<bool> UniqueServerHashValidationEnabled =
+        CVarDef.Create("shuttle.unique_server_hash_validation_enabled", true, CVar.SERVERONLY);
 
     /// <summary>
     ///     Maximum charge applied when loading a ship through a shipyard console.


### PR DESCRIPTION
## About the PR
Shuttle/Ships now have a hard limit of 50.000 bucks when loading from storage

## Why / Balance
Some players experienced costs such as 100k for a simple steel box.

## Technical details
In the loading mechanism it checks the price from "Appraisal", it takes 10% of this total price and then checks if its more then 50.000, if so, it caps it at 50.000, if not, it gives the appraised (10%) price.

## How to test
Load a saved ship thats worth more then 500.000

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- Either:
- [ ] I have given credit the right people in the right [attributions.yml (example)](https://github.com/SandwichStation/SandwichStation-HL/blob/master/Resources/Audio/_ShibaStation/Lobby/attributions.yml) file
- [X] I own the rights to the added content
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Shipyards no longer charge more then 50.000 bucks for loading a stored ship
