### PR TITLE
Add dockable components and cross-grid functionality

### DIFF
--- a/Content.Server/Disposal/Tube/DisposalTubeSystem.cs
+++ b/Content.Server/Disposal/Tube/DisposalTubeSystem.cs
@@ -1,9 +1,11 @@
 using System.Linq;
 using System.Text;
+using Content.Server._NF.Disposal.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Construction.Completions;
 using Content.Server.Disposal.Unit;
 using Content.Server.Popups;
+using Content.Server.Shuttles.Components;
 using Content.Shared.Destructible;
 using Content.Shared.Disposal.Components;
 using Content.Shared.Disposal.Tube;
@@ -363,6 +365,16 @@ namespace Content.Server.Disposal.Tube
                 }
 
                 return entity;
+            }
+
+            // Cross-grid disposal via docking
+            if (HasComp<DockableDisposalComponent>(target)
+                && TryComp(target, out DockingComponent? docking)
+                && docking.DockedWith != null
+                && TryComp(docking.DockedWith, out DisposalTubeComponent? dockedTube)
+                && dockedTube.Connected)
+            {
+                return docking.DockedWith;
             }
 
             return null;

--- a/Content.Server/Power/Nodes/CableNode.cs
+++ b/Content.Server/Power/Nodes/CableNode.cs
@@ -7,7 +7,8 @@ using Robust.Shared.Map.Components;
 namespace Content.Server.Power.Nodes
 {
     [DataDefinition]
-    public sealed partial class CableNode : Node
+    [Virtual]
+    public partial class CableNode : Node
     {
         public override IEnumerable<Node> GetReachableNodes(TransformComponent xform,
             EntityQuery<NodeContainerComponent> nodeQuery,

--- a/Content.Server/_NF/Atmos/Components/DockablePipeComponent.cs
+++ b/Content.Server/_NF/Atmos/Components/DockablePipeComponent.cs
@@ -6,14 +6,20 @@ namespace Content.Server._NF.Atmos.Components;
 public sealed partial class DockablePipeComponent : Component
 {
     /// <summary>
+    /// The names of the nodes that are available to dock.
+    /// </summary>
+    [DataField]
+    public List<string> DockNodeNames = new();
+
+    /// <summary>
     /// The name of the node that is available to dock.
     /// </summary>
     [DataField]
-    public string DockNodeName;
+    public string DockNodeName = string.Empty;
 
     /// <summary>
     /// The name of the internal node
     /// </summary>
     [DataField]
-    public string InternalNodeName;
+    public string InternalNodeName = string.Empty;
 }

--- a/Content.Server/_NF/Atmos/Systems/DockablePipeSystem.cs
+++ b/Content.Server/_NF/Atmos/Systems/DockablePipeSystem.cs
@@ -24,26 +24,42 @@ public sealed class DockablePipeSystem : EntitySystem
 
     private void OnDock(Entity<DockablePipeComponent> ent, ref DockEvent args)
     {
-        // Reflood node?
-        if (string.IsNullOrEmpty(ent.Comp.DockNodeName) ||
-            !TryComp(ent, out NodeContainerComponent? nodeContainer) ||
-            !_nodeContainer.TryGetNode(nodeContainer, ent.Comp.DockNodeName, out DockablePipeNode? dockablePipe))
+        if (!TryComp(ent, out NodeContainerComponent? nodeContainer))
             return;
 
-        _nodeGroup.QueueReflood(dockablePipe);
+        var nodeNames = GetAllNodeNames(ent.Comp);
+        foreach (var name in nodeNames)
+        {
+            if (_nodeContainer.TryGetNode(nodeContainer, name, out DockablePipeNode? dockablePipe))
+                _nodeGroup.QueueReflood(dockablePipe);
+        }
+
         _appearance.SetData(ent, DockablePipeVisuals.Docked, true);
     }
 
     private void OnUndock(Entity<DockablePipeComponent> ent, ref UndockEvent args)
     {
-        // Clean up node?
-        if (string.IsNullOrEmpty(ent.Comp.DockNodeName) ||
-            !TryComp(ent, out NodeContainerComponent? nodeContainer) ||
-            !_nodeContainer.TryGetNode(nodeContainer, ent.Comp.DockNodeName, out DockablePipeNode? dockablePipe))
+        if (!TryComp(ent, out NodeContainerComponent? nodeContainer))
             return;
 
-        _nodeGroup.QueueNodeRemove(dockablePipe);
-        dockablePipe.Air.Clear();
+        var nodeNames = GetAllNodeNames(ent.Comp);
+        foreach (var name in nodeNames)
+        {
+            if (_nodeContainer.TryGetNode(nodeContainer, name, out DockablePipeNode? dockablePipe))
+            {
+                _nodeGroup.QueueNodeRemove(dockablePipe);
+                dockablePipe.Air.Clear();
+            }
+        }
+
         _appearance.SetData(ent, DockablePipeVisuals.Docked, false);
+    }
+
+    private List<string> GetAllNodeNames(DockablePipeComponent comp)
+    {
+        var names = new List<string>(comp.DockNodeNames);
+        if (!string.IsNullOrEmpty(comp.DockNodeName) && !names.Contains(comp.DockNodeName))
+            names.Add(comp.DockNodeName);
+        return names;
     }
 }

--- a/Content.Server/_NF/Disposal/Components/DockableDisposalComponent.cs
+++ b/Content.Server/_NF/Disposal/Components/DockableDisposalComponent.cs
@@ -1,0 +1,8 @@
+using Content.Server._NF.Disposal.Systems;
+
+namespace Content.Server._NF.Disposal.Components;
+
+[RegisterComponent, Access(typeof(DockableDisposalSystem))]
+public sealed partial class DockableDisposalComponent : Component
+{
+}

--- a/Content.Server/_NF/Disposal/Systems/DockableDisposalSystem.cs
+++ b/Content.Server/_NF/Disposal/Systems/DockableDisposalSystem.cs
@@ -1,0 +1,29 @@
+using Content.Server._NF.Disposal.Components;
+using Content.Server.Shuttles.Events;
+using Content.Shared._NF.Disposal.Visuals;
+using Robust.Server.GameObjects;
+
+namespace Content.Server._NF.Disposal.Systems;
+
+public sealed class DockableDisposalSystem : EntitySystem
+{
+    [Dependency] private readonly AppearanceSystem _appearance = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DockableDisposalComponent, DockEvent>(OnDock);
+        SubscribeLocalEvent<DockableDisposalComponent, UndockEvent>(OnUndock);
+    }
+
+    private void OnDock(Entity<DockableDisposalComponent> ent, ref DockEvent args)
+    {
+        _appearance.SetData(ent, DockableDisposalVisuals.Docked, true);
+    }
+
+    private void OnUndock(Entity<DockableDisposalComponent> ent, ref UndockEvent args)
+    {
+        _appearance.SetData(ent, DockableDisposalVisuals.Docked, false);
+    }
+}

--- a/Content.Server/_NF/NodeContainer/Nodes/DockableCableNode.cs
+++ b/Content.Server/_NF/NodeContainer/Nodes/DockableCableNode.cs
@@ -1,23 +1,22 @@
+using Content.Server.Power.Nodes;
 using Content.Server.Shuttles.Components;
 using Content.Shared.NodeContainer;
 using Robust.Shared.Map.Components;
 
 namespace Content.Server.NodeContainer.Nodes;
 
-
-[DataDefinition, Virtual]
-public partial class DockablePipeNode : PipeNode
+[DataDefinition]
+public sealed partial class DockableCableNode : CableNode
 {
-
     public override IEnumerable<Node> GetReachableNodes(TransformComponent xform,
         EntityQuery<NodeContainerComponent> nodeQuery,
         EntityQuery<TransformComponent> xformQuery,
         MapGridComponent? grid,
         IEntityManager entMan)
     {
-        foreach (var pipe in base.GetReachableNodes(xform, nodeQuery, xformQuery, grid, entMan))
+        foreach (var node in base.GetReachableNodes(xform, nodeQuery, xformQuery, grid, entMan))
         {
-            yield return pipe;
+            yield return node;
         }
 
         if (!xform.Anchored || grid == null)
@@ -29,8 +28,8 @@ public partial class DockablePipeNode : PipeNode
         {
             foreach (var node in otherNode.Nodes.Values)
             {
-                if (node is DockablePipeNode pipe && pipe.CurrentPipeLayer == CurrentPipeLayer)
-                    yield return pipe;
+                if (node is DockableCableNode cable)
+                    yield return cable;
             }
         }
     }

--- a/Content.Server/_NF/Power/Components/DockablePowerComponent.cs
+++ b/Content.Server/_NF/Power/Components/DockablePowerComponent.cs
@@ -1,0 +1,10 @@
+using Content.Server._NF.Power.Systems;
+
+namespace Content.Server._NF.Power.Components;
+
+[RegisterComponent, Access(typeof(DockablePowerSystem))]
+public sealed partial class DockablePowerComponent : Component
+{
+    [DataField]
+    public string DockNodeName;
+}

--- a/Content.Server/_NF/Power/Systems/DockablePowerSystem.cs
+++ b/Content.Server/_NF/Power/Systems/DockablePowerSystem.cs
@@ -1,0 +1,46 @@
+using Content.Server._NF.Power.Components;
+using Content.Server.NodeContainer.EntitySystems;
+using Content.Server.NodeContainer.Nodes;
+using Content.Server.Shuttles.Events;
+using Content.Shared._NF.Power.Visuals;
+using Content.Shared.NodeContainer;
+using Robust.Server.GameObjects;
+
+namespace Content.Server._NF.Power.Systems;
+
+public sealed class DockablePowerSystem : EntitySystem
+{
+    [Dependency] private readonly AppearanceSystem _appearance = default!;
+    [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
+    [Dependency] private readonly NodeGroupSystem _nodeGroup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DockablePowerComponent, DockEvent>(OnDock);
+        SubscribeLocalEvent<DockablePowerComponent, UndockEvent>(OnUndock);
+    }
+
+    private void OnDock(Entity<DockablePowerComponent> ent, ref DockEvent args)
+    {
+        if (string.IsNullOrEmpty(ent.Comp.DockNodeName) ||
+            !TryComp(ent, out NodeContainerComponent? nodeContainer) ||
+            !_nodeContainer.TryGetNode(nodeContainer, ent.Comp.DockNodeName, out DockableCableNode? dockableCable))
+            return;
+
+        _nodeGroup.QueueReflood(dockableCable);
+        _appearance.SetData(ent, DockablePowerVisuals.Docked, true);
+    }
+
+    private void OnUndock(Entity<DockablePowerComponent> ent, ref UndockEvent args)
+    {
+        if (string.IsNullOrEmpty(ent.Comp.DockNodeName) ||
+            !TryComp(ent, out NodeContainerComponent? nodeContainer) ||
+            !_nodeContainer.TryGetNode(nodeContainer, ent.Comp.DockNodeName, out DockableCableNode? dockableCable))
+            return;
+
+        _nodeGroup.QueueNodeRemove(dockableCable);
+        _appearance.SetData(ent, DockablePowerVisuals.Docked, false);
+    }
+}

--- a/Content.Shared/_NF/Disposal/Visuals/DockableDisposalVisuals.cs
+++ b/Content.Shared/_NF/Disposal/Visuals/DockableDisposalVisuals.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._NF.Disposal.Visuals;
+
+[Serializable, NetSerializable]
+public enum DockableDisposalVisuals : byte
+{
+    Docked, // bool
+}

--- a/Content.Shared/_NF/Power/Visuals/DockablePowerVisuals.cs
+++ b/Content.Shared/_NF/Power/Visuals/DockablePowerVisuals.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._NF.Power.Visuals;
+
+[Serializable, NetSerializable]
+public enum DockablePowerVisuals : byte
+{
+    Docked, // bool
+}

--- a/Resources/Prototypes/_NF/Entities/Structures/Doors/Airlocks/utility_dock.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Doors/Airlocks/utility_dock.yml
@@ -1,0 +1,58 @@
+- type: entity
+  parent: AirlockShuttleAssembly
+  id: AirlockShuttleUtilityAssembly
+  name: utility dock assembly
+  suffix: Docking, Utility
+  description: An incomplete utility dock. Transfers HV power, atmos piping, and disposal between docked grids.
+  components:
+  - type: Construction
+    graph: AirlockShuttleUtility
+    node: assembly
+
+- type: entity
+  parent: AirlockShuttle
+  id: AirlockShuttleUtility
+  name: utility dock
+  suffix: Docking, Power/Pipe/Disposal
+  description: A docking airlock that transfers HV power, atmos piping, and disposal between docked grids.
+  components:
+  - type: Construction
+    graph: AirlockShuttleUtility
+    node: airlock
+  # Cross-grid power and pipe nodes
+  - type: NodeContainer
+    nodes:
+      cable:
+        !type:DockableCableNode
+        nodeGroupID: HVPower
+      pipe0:
+        !type:DockablePipeNode
+        nodeGroupID: Pipe
+        pipeDirection: Fourway
+        pipeLayer: 0
+      pipe1:
+        !type:DockablePipeNode
+        nodeGroupID: Pipe
+        pipeDirection: Fourway
+        pipeLayer: 1
+      pipe2:
+        !type:DockablePipeNode
+        nodeGroupID: Pipe
+        pipeDirection: Fourway
+        pipeLayer: 2
+  - type: DockablePipe
+    dockNodeNames:
+    - pipe0
+    - pipe1
+    - pipe2
+  - type: DockablePower
+    dockNodeName: cable
+  # Cross-grid disposal
+  - type: DisposalTube
+    containerId: DisposalTransit
+  - type: DisposalTransit
+  - type: DockableDisposal
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
+      DisposalTransit: !type:Container

--- a/Resources/Prototypes/_NF/Recipes/Construction/Graphs/structures/utility_dock.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/Graphs/structures/utility_dock.yml
@@ -1,0 +1,192 @@
+- type: constructionGraph
+  id: AirlockShuttleUtility
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: assembly
+      completed:
+      - !type:SetAnchor
+        value: false
+      steps:
+      - material: Plasteel
+        amount: 2
+        doAfter: 2
+
+  - node: assembly
+    entity: AirlockShuttleUtilityAssembly
+    actions:
+    - !type:SnapToGrid {}
+    - !type:SetAnchor {}
+    edges:
+    - to: electronics
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - component: DoorElectronics
+        store: board
+        name: construction-graph-component-door-electronics-circuit-board
+        icon:
+          sprite: "Objects/Misc/module.rsi"
+          state: "door_electronics"
+        doAfter: 1
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetPlasteel1
+        amount: 2
+      - !type:DeleteEntity {}
+      steps:
+      - tool: Welding
+        doAfter: 3
+
+  - node: electronics
+    edges:
+    - to: wired
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: Cable
+        amount: 5
+        doAfter: 2.5
+    - to: assembly
+      completed:
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
+      steps:
+      - tool: Prying
+        doAfter: 1
+
+  - node: wired
+    edges:
+    - to: electronics
+      completed:
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 5
+      steps:
+      - tool: Cutting
+        doAfter: 2
+    - to: skeleton
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: Plasteel
+        amount: 2
+        doAfter: 1
+
+  - node: skeleton
+    edges:
+    - to: skeletonWrenched
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - tool: Anchoring
+        doAfter: 2
+    - to: wired
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetPlasteel1
+        amount: 2
+      steps:
+      - tool: Prying
+        doAfter: 2
+
+  - node: skeletonWrenched
+    edges:
+    - to: skeletonWelded
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - tool: Welding
+        doAfter: 2
+    - to: skeleton
+      steps:
+      - tool: Anchoring
+        doAfter: 2
+
+  - node: skeletonWelded
+    edges:
+    - to: skeletonSilver
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: Silver
+        amount: 2
+        doAfter: 1
+    - to: skeletonWrenched
+      steps:
+      - tool: Welding
+        doAfter: 2
+
+  - node: skeletonSilver
+    entity: AirlockShuttleUtilityAssembly
+    edges:
+    - to: utilityWired
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: Cable
+        amount: 5
+        doAfter: 2
+    - to: skeletonWelded
+      completed:
+      - !type:SpawnPrototype
+        prototype: IngotSilver1
+        amount: 2
+      steps:
+      - tool: Prying
+        doAfter: 2
+
+  - node: utilityWired
+    edges:
+    - to: utilityPiped
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 2
+    - to: skeletonSilver
+      completed:
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 5
+      steps:
+      - tool: Cutting
+        doAfter: 2
+
+  - node: utilityPiped
+    edges:
+    - to: airlock
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - tool: Screwing
+        doAfter: 2
+    - to: utilityWired
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      steps:
+      - tool: Prying
+        doAfter: 2
+
+  - node: airlock
+    entity: AirlockShuttleUtility
+    edges:
+    - to: utilityPiped
+      conditions:
+      - !type:EntityAnchored {}
+      - !type:DoorWelded {}
+      - !type:DoorBolted
+        value: false
+      - !type:WirePanel {}
+      steps:
+      - tool: Prying
+        doAfter: 5

--- a/Resources/Prototypes/_NF/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/structures.yml
@@ -57,3 +57,17 @@
   canBuildInImpassable: false
   conditions:
     - !type:TileNotBlocked
+
+- type: construction
+  id: AirlockShuttleUtility
+  name: utility dock
+  description: A docking airlock that transfers HV power, atmos piping, and disposal between docked grids.
+  graph: AirlockShuttleUtility
+  startNode: start
+  targetNode: airlock
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked


### PR DESCRIPTION
## About the PR
Adds a new docking airlock variant (`AirlockShuttleUtility`) that bridges HV power, atmos piping, and disposal tubes between docked grids. When two utility docks connect, all three networks automatically merge; when they undock, the networks cleanly split.

## Why / Balance
Currently docking only provides a physical connection between grids. Engineers have no way to extend power, piping, or disposal across docked shuttles. This adds meaningful infrastructure gameplay — shuttles can share power grids and disposal networks through dedicated utility docks. Atmos piping is included but each shuttle still needs its own gas canisters and scrubber system to harvest and dispose of waste gases, keeping atmos gameplay relevant.

## Technical details
- `DockableCableNode` — new node type extending `CableNode`, overrides `GetReachableNodes()` to yield cable nodes from docked grid via `DockingComponent.DockedWith` (mirrors existing `DockablePipeNode` pattern)
- `DockablePowerComponent` / `DockablePowerSystem` — handles dock/undock events, triggers `QueueReflood` / `QueueNodeRemove` on the cable node group
- `DockableDisposalComponent` / `DockableDisposalSystem` — handles dock/undock events for disposal visual state
- `DisposalTubeSystem.NextTubeFor()` — added cross-grid fallback that checks `DockableDisposalComponent` + `DockingComponent.DockedWith` when no local tube is found
- `CableNode` changed from `sealed` to `[Virtual]` to allow inheritance
- `DockablePowerVisuals` / `DockableDisposalVisuals` — shared enums for appearance data

## How to test
1. Admin-spawn two `AirlockShuttleUtility` on separate grids.
2. On each grid, connect HV cable, atmos pipe, and a disposal tube to the airlock
3. Dock the grids via shuttle console
4. Verify: power network merges (SMES on grid A powers devices on grid B), gas flows between grids through pipes, disposal items sent from grid A arrive at grid B
5. Undock and verify all three networks split cleanly

## Media


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- Either:
- [X] I own the rights to the added content

## Breaking changes
`CableNode` changed from `sealed` to `[Virtual]` to allow `DockableCableNode` to inherit from it. No public API changes.

**Changelog**
:cl:
- add: New utility dock airlock (AirlockShuttleUtility) that bridges HV power, atmos piping, and disposal tubes between docked grids.
