### PR TITLE
fix instruments

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/base_instruments.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/base_instruments.yml
@@ -7,7 +7,7 @@
   - type: Sprite
   - type: Instrument
   - type: ActivatableUI
-    inHandsOnly: true
+    inHandsOnly: false
     singleUser: true
     verbText: verb-instrument-openui
     key: enum.InstrumentUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/base_instruments.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/base_instruments.yml
@@ -7,8 +7,9 @@
   - type: Sprite
   - type: Instrument
   - type: ActivatableUI
-    inHandsOnly: false
+    inHandsOnly: false # Sandwich: true>false, let us play them even not in our hands!
     singleUser: true
+    requireActiveHand: false # Sandwich: Also dont require them to be in the active hand
     verbText: verb-instrument-openui
     key: enum.InstrumentUiKey.Key
   - type: UserInterface


### PR DESCRIPTION
allow them to be used outside of the hands, for example the floor around the player, the pockets, or their bag

## About the PR
set the hand requirement in the base instrument prototype to false

## Why / Balance
musicians can actually music without stopping every 2 seconds to do something in-game

## Technical details
set the hand requirement in the base instrument prototype to false

## How to test
Use an instrument item, place it in the players pockets or bag, the UI does not close like it used to, this also allows the player to switch their hands via X (default) to something else without stopping the music

## Media
None

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).

## Breaking changes
Some special instruments that expect the default state to be handfull may not override to become handful now

**Changelog**
:cl:
- fix: Fixed instruments allowing them to be used outside of hand slots.
