### PR TITLE
Create SPDX clutter check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,7 @@ Small fixes/refactors are exempt. Media may be used in SS14 progress reports wit
 <!-- Confirm the following by placing an X in the brackets [X]: -->
 - [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
 - [ ] I have added media to this PR or it does not require an ingame showcase.
+- [ ] My PR does not add or contain any [SPDX headers](https://github.com/SandwichStation/SandwichStation-HL/?tab=contributing-ov-file#user-content-no-spdx-headers)
 - Either:
 - [ ] I have given credit the right people in the right [attributions.yml (example)](https://github.com/SandwichStation/SandwichStation-HL/blob/master/Resources/Audio/_ShibaStation/Lobby/attributions.yml) file
 - [ ] I own the rights to the added content
@@ -27,13 +28,8 @@ Small fixes/refactors are exempt. Media may be used in SS14 progress reports wit
 <!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
 
 **Changelog**
-<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
-Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
-Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
-<!--
 :cl:
 - add: Added fun!
 - remove: Removed fun!
 - tweak: Changed fun!
 - fix: Fixed fun!
--->

--- a/.github/workflows/check-spdx.yml
+++ b/.github/workflows/check-spdx.yml
@@ -38,6 +38,7 @@ jobs:
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.event.pull_request.head.sha }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
 
           failing_files=""
           warning_files=""
@@ -59,15 +60,23 @@ jobs:
             fi
           done
 
+          # Delete previous SPDX check comments
+          comment_ids=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[] | select(.body | contains("<!-- spdx-check-bot -->")) | .id' || true)
+          for cid in $comment_ids; do
+            gh api -X DELETE "repos/$REPO/issues/comments/$cid" || true
+          done
+
+          MARKER="<!-- spdx-check-bot -->"
+
           if [ -n "$warning_files" ]; then
             warning_files="${warning_files#${NL}}"
-            body=$(printf "⚠️ These files contain existing SPDX headers that should be removed:\n%s\n\nThe check will pass, but please consider removing them." "$warning_files")
+            body=$(printf "%s\n⚠️ These files contain existing SPDX headers that should be removed:\n%s\n\nThe check will pass, but please consider removing them." "$MARKER" "$warning_files")
             gh pr comment "$PR_NUMBER" --body "$body"
           fi
 
           if [ -n "$failing_files" ]; then
             failing_files="${failing_files#${NL}}"
-            body=$(printf "SPDX check failed on the following files:\n%s\n\nPlease remove the headers from your PR" "$failing_files")
+            body=$(printf "%s\nSPDX check failed on the following files:\n%s\n\nPlease remove the headers from your PR" "$MARKER" "$failing_files")
             gh pr comment "$PR_NUMBER" --body "$body"
             exit 1
           else

--- a/.github/workflows/check-spdx.yml
+++ b/.github/workflows/check-spdx.yml
@@ -1,0 +1,51 @@
+name: SPDX Header Check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check-spdx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Bot Token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.bot-token.outputs.token }}
+
+      - name: Check for SPDX headers in added lines
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          offending_files=""
+
+          for file in $(git diff "$BASE..$HEAD" --diff-filter=d --name-only); do
+            added_spdx=$(git diff "$BASE..$HEAD" -- "$file" | grep -E '^\+' | grep -E '^\+.*(SPDX-FileCopyrightText|SPDX-License-Identifier)' || true)
+            if [ -n "$added_spdx" ]; then
+              offending_files="${offending_files}\n${file}"
+            fi
+          done
+
+          if [ -n "$offending_files" ]; then
+            body=$(printf "SPDX check failed on the following files:\n%s\n\nPlease remove the headers from your PR" "$offending_files")
+            gh pr comment "$PR_NUMBER" --body "$body"
+            exit 1
+          else
+            echo "✅ No SPDX headers found in newly added lines."
+          fi

--- a/.github/workflows/check-spdx.yml
+++ b/.github/workflows/check-spdx.yml
@@ -2,6 +2,7 @@ name: SPDX Header Check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -9,6 +10,11 @@ permissions:
 jobs:
   check-spdx:
     runs-on: ubuntu-latest
+    if: |
+      github.event.action == 'opened' ||
+      github.event.action == 'reopened' ||
+      github.event.action == 'ready_for_review' ||
+      (github.event.action == 'synchronize' && github.event.pull_request.draft == false)
     steps:
       - name: Generate Bot Token
         id: bot-token
@@ -33,17 +39,35 @@ jobs:
           HEAD="${{ github.event.pull_request.head.sha }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
 
-          offending_files=""
+          failing_files=""
+          warning_files=""
+          NL=$'\n'
 
           for file in $(git diff "$BASE..$HEAD" --diff-filter=d --name-only); do
+            # Skip files that legitimately contain SPDX strings
+            case "$file" in
+              .github/workflows/check-spdx.yml) continue ;;
+              CONTRIBUTING.md) continue ;;
+            esac
+
             added_spdx=$(git diff "$BASE..$HEAD" -- "$file" | grep -E '^\+' | grep -E '^\+.*(SPDX-FileCopyrightText|SPDX-License-Identifier)' || true)
+
             if [ -n "$added_spdx" ]; then
-              offending_files="${offending_files}\n${file}"
+              failing_files="${failing_files}${NL}${file}"
+            elif grep -Eq '(SPDX-FileCopyrightText|SPDX-License-Identifier)' "$file"; then
+              warning_files="${warning_files}${NL}${file}"
             fi
           done
 
-          if [ -n "$offending_files" ]; then
-            body=$(printf "SPDX check failed on the following files:\n%s\n\nPlease remove the headers from your PR" "$offending_files")
+          if [ -n "$warning_files" ]; then
+            warning_files="${warning_files#${NL}}"
+            body=$(printf "⚠️ These files contain existing SPDX headers that should be removed:\n%s\n\nThe check will pass, but please consider removing them." "$warning_files")
+            gh pr comment "$PR_NUMBER" --body "$body"
+          fi
+
+          if [ -n "$failing_files" ]; then
+            failing_files="${failing_files#${NL}}"
+            body=$(printf "SPDX check failed on the following files:\n%s\n\nPlease remove the headers from your PR" "$failing_files")
             gh pr comment "$PR_NUMBER" --body "$body"
             exit 1
           else

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,15 @@ An edit to a Delta-V locale file, note the `OLD<NEW` format and the separate lin
 # Sandwich: "Job Whitelists"<"Role Whitelists"
 player-panel-job-whitelists = Role Whitelists
 ```
+## No SPDX Headers
+
+Do **not** add SPDX headers (`SPDX-FileCopyrightText` or `SPDX-License-Identifier`) to any files in your PRs. This applies to both new files and modifications to existing ones.
+
+The entire codebase is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0-or-later)** as stated in the `LICENSE` file. Per-file SPDX headers are unnecessary and create several problems:
+
+- They imply individual copyright ownership on a per-file basis, which doesn't reflect how collaborative development works — a one-line change shouldn't grant copyright over a 300-line file.
+- They bloat files with repeated metadata that duplicates what the repo-level `LICENSE` already covers.
+- They create inconsistent attribution when files are ported or cherry-picked between forks.
 
 # Mapping
 


### PR DESCRIPTION
## About the PR
Adds a system to banish SPDX headers in new PR's, they suck

## Why / Balance
The entire codebase is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0-or-later) as stated in the LICENSE file. Per-file SPDX headers are unnecessary and create several problems:

- They imply individual copyright ownership on a per-file basis, which doesn't reflect how collaborative development works — a one-line change shouldn't grant copyright over a 300-line file.
- They bloat files with repeated metadata that duplicates what the repo-level LICENSE already covers.
- They create inconsistent attribution when files are ported or cherry-picked between forks.

## Breaking changes
None, its a warning for new PR's 
doesnt restrict old ones